### PR TITLE
Remove jshint and only use eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,4 @@
+# Ignore anything downloaded with npm when running eslint
 node_modules/
+# Ignore legacy spreadsheet file when running eslint
 wow.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,5 @@
+// Documentation:
+//   http://eslint.org/docs/rules/
 module.exports = {
     "env": {
         "browser": true

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,11 @@ module.exports = {
     },
     "extends": "eslint:recommended",
     "rules": {
+        // Braces should be on their own lines
+        "brace-style": [
+            "error",
+            "allman"
+        ],
         // Indent code with 4 spaces
         "indent": [
             "error",
@@ -14,6 +19,19 @@ module.exports = {
                 "SwitchCase": 1,
                 "MemberExpression": 1
             }
+        ],
+        // Objects with more than 3 properties should be on multiple lines
+        "object-curly-newline": [
+            "error",
+            {
+                "multiline": true,
+                "minProperties": 3
+            }
+        ],
+        // Objects should have spaces around curly braces for readability
+        "object-curly-spacing": [
+            "error",
+            "always"
         ],
         // Use double quotes for strings
         "quotes": [
@@ -25,39 +43,15 @@ module.exports = {
             "error",
             "always"
         ],
-        // Braces should be on their own lines
-        "brace-style": [
-            "error",
-            "allman"
-        ],
-        // Ensure spaces are around keywords
-        "keyword-spacing": [
-            "error"
-        ],
-        // Objects should have spaces around curly braces for readability
-        "object-curly-spacing": [
-            "error",
-            "always"
-        ],
-        // Objects with more than 3 properties should be on multiple lines
-        "object-curly-newline": [
-            "error",
-            {
-                "multiline": true,
-                "minProperties": 3
-            }
-        ],
-        // Do not allow more than 2 consecutive newlines
-        "no-multiple-empty-lines": [
-            "error"
-        ],
-        // Do not allow Array(), use [] notation instead
-        "no-array-constructor": [
-            "error"
-        ],
-        // Switch statements should always have a default case
-        "default-case": [
-            "error"
-        ]
+        "default-case":            2, // Switch statements should always have a default case
+        "keyword-spacing":         2, // Ensure spaces are around keywords
+        "no-array-constructor":    2, // Do not allow Array(), use [] notation instead
+        "no-bitwise":              2, // Disallow bitwise operators
+        "no-multiple-empty-lines": 2, // Do not allow more than 2 consecutive newlines
+        "curly":                   2, // Control structures should always have curly braces
+        "no-extend-native":        2, // Disallow extending of native javascript objects
+        "no-caller":               2, // Disallow use of caller/callee
+        "no-shadow":               2, // Disallow shadowed variable declarations
+        "dot-notation":            2, // Enforce dot notation when possible
     }
 };

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+# Ignore anything in Git downloaded with npm
 node_modules/

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,2 +1,0 @@
-node_modules/
-wow.js

--- a/guildoutput.js
+++ b/guildoutput.js
@@ -56,18 +56,18 @@ function guild(region,realmName,guildName,opt_sort)
 
 
     var guildJSON = UrlFetchApp.fetch("https://"+region+".api.battle.net/wow/guild/"+realmName+"/"+guildName+"?fields=members&?locale=en_US&apikey="+apikey+"");
-    var guild = JSON.parse(guildJSON);
+    var guildData = JSON.parse(guildJSON);
     // XXX: Unused variable?
-    //var memberTotal = guild.members.length;
+    //var memberTotal = guildData.members.length;
     var membermatrix = [ ];
     var i = 0;
 
     // sort by number of cheevo points
     if (opt_sort)
     {
-        for (i=0; i<guild.members.length; i++)
+        for (i=0; i<guildData.members.length; i++)
         {
-            membermatrix[i] = [guild.members[i].character.achievementPoints, guild.members[i].character.name, guild.members[i].rank];
+            membermatrix[i] = [guildData.members[i].character.achievementPoints, guildData.members[i].character.name, guildData.members[i].rank];
         }
 
         membermatrix.sort(sortFunction);  //  membermatrix[].sort(function(a, b){return b-a});
@@ -83,10 +83,10 @@ function guild(region,realmName,guildName,opt_sort)
             membermatrix[i] = [];
         }
 
-        for (i=0; i<guild.members.length; i++)
+        for (i=0; i<guildData.members.length; i++)
         {
-            rank=guild.members[i].rank;
-            membermatrix[rank].push(guild.members[i].character.name);
+            rank=guildData.members[i].rank;
+            membermatrix[rank].push(guildData.members[i].character.name);
         }
     }
 

--- a/mounts.js
+++ b/mounts.js
@@ -219,14 +219,23 @@ function farm(region, realmName, toonName, list)
     var midnight = new Date();
     midnight.setHours(0, 0, 0, 0);
 
-    if (today == 2) //it IS tuesday!
+    if (today == 2)
+    {
+        //it IS tuesday!
         sinceTuesday = todayStamp - midnight + 32400;
+    }
 
-    else if (today > 2) // wednesday - saturday
+    else if (today > 2)
+    {
+        // wednesday - saturday
         sinceTuesday = (today - 1) * 86400000;
+    }
 
-    else if (today < 2) // sunday + monday
+    else if (today < 2)
+    {
+        // sunday + monday
         sinceTuesday = (today + 6) * 86400000;
+    }
 
 
     // now we have to figure out how long it's been since yesterday's reset

--- a/package.json
+++ b/package.json
@@ -1,14 +1,11 @@
 {
   "name": "wowspreadsheet",
   "description": "World of Warcraft character tracking spreadsheet for Google Docs",
-  "dependencies": {
-    "jshint": "^2.9.3"
-  },
   "devDependencies": {
     "eslint": "^3.4.0"
   },
   "scripts": {
-    "test": "./node_modules/.bin/jshint . && ./node_modules/.bin/eslint ."
+    "test": "./node_modules/.bin/eslint ."
   },
   "repository": {
     "type": "git",

--- a/wow_legion.js
+++ b/wow_legion.js
@@ -358,10 +358,14 @@ function wow(region,toonName,realmName)
 
 
     if (boolCheapGems == 1)
+    {
         auditInfo = auditInfo + cheapGems;
+    }
 
     if (boolNonEpicGems == 1)
+    {
         auditInfo = auditInfo + nonEpicGems;
+    }
 
 
     // lock out "Weekly checker"
@@ -419,11 +423,17 @@ function wow(region,toonName,realmName)
         }
     }
 
-    if (today > reset) // wednesday (thurs eu) - saturday
+    if (today > reset)
+    {
+        // wednesday (thurs eu) - saturday
         sinceTuesday = sinceTuesday-(today-reset)*86400000;
+    }
 
-    else if (today < reset) // sunday + monday (tues eu)
+    else if (today < reset)
+    {
+        // sunday + monday (tues eu)
         sinceTuesday = sinceTuesday-((7+today-reset))*86400000; // this was 6, but to account for EU it was changed to 7-reset to be either 6 or 5 to account for Wednesday resets
+    }
 
 
     //WORLD BOSSES


### PR DESCRIPTION
Rather than having two tools to test the javascript code, only use one (`eslint`). 

I added the equivalent rules to `eslint`'s config file, so it checks the same things `jshint` did before. Therefore, `jshint` is no longer needed. 

You still run the tests the same way, by calling `npm test`. 

I also added some comments to the misc config files. 
