### PR TITLE
Add island expeditions check

### DIFF
--- a/wow_bfa.js
+++ b/wow_bfa.js
@@ -814,6 +814,7 @@ function wow(region,toonName,realmName)
 
     var worldBossKill = "";
     var warfront = "";
+    var islandExpeditions = "-";
 
     for (i=0; i < toon.quests.length; i++)
     {
@@ -836,6 +837,10 @@ function wow(region,toonName,realmName)
         if (toon.quests[i] == 53955 || toon.quests[i] == 53992)
         {
             warfront = warfront + "Darkshore: \u2713 ";
+        }
+        if (toon.quests[i] == 53435 || toon.quests[i] == 53436)
+        {
+            islandExpeditions = "\u2713 ";
         }
     } 
 


### PR DESCRIPTION
Because warfront is not in the output by default I also kept this island expedition check optional