### PR TITLE
Fix corruption resistance check on essences

### DIFF
--- a/wow_bfa.js
+++ b/wow_bfa.js
@@ -1034,10 +1034,10 @@ function equipment(region,realmName,toonName)
                     {
                         if (gear.equipped_items[i].azerite_details.selected_essences[j].rank) // if there's no rank there's no reason to continue
                         {
-                            var resistCheck = gear.equipped_items[i].azerite_details.selected_essences[j].passive_spell_tooltip.description.split(":  ");
-                            if (resistCheck[1] == "Corruption Resistance increased by 10.")
+                            var resistCheck = gear.equipped_items[i].azerite_details.selected_essences[j].passive_spell_tooltip.description.indexOf("Corruption Resistance increased by 10.");
+                            if (resistCheck > -1)
                             {
-                                totalStats[7] = 10;
+                                totalStats[7] += 10;
                             }
                             var shortName = function (str1)
                             {


### PR DESCRIPTION
Some essences have one and other have two spaces after the colon in "Unique:  Corruption..." (yay Blizz consistency) and because you already check for an exact string value why not directly search for its position instead of doing this risky split.
Also changed "totalStats[7] += 10;" to be ready for the case if the order of returned values in the API might change one day. The old version would overwrite the existing value instead of adding to it. Works currently because NECK is after/below the BACK item.