### PR TITLE
Fix multiple corruption resistance essences

### DIFF
--- a/wow_bfa.js
+++ b/wow_bfa.js
@@ -1034,6 +1034,7 @@ function equipment(region,realmName,toonName)
           
             if (gear.equipped_items[i].azerite_details.level.value>= 35 && gear.equipped_items[i].azerite_details.selected_essences)
             {
+                var corruptionResistanceApplied = false;
                 for (j=0; j<gear.equipped_items[i].azerite_details.selected_essences.length; j++)
                 {
                     if (gear.equipped_items[i].azerite_details.selected_essences)
@@ -1041,9 +1042,10 @@ function equipment(region,realmName,toonName)
                         if (gear.equipped_items[i].azerite_details.selected_essences[j].rank) // if there's no rank there's no reason to continue
                         {
                             var resistCheck = gear.equipped_items[i].azerite_details.selected_essences[j].passive_spell_tooltip.description.indexOf("Corruption Resistance increased by 10.");
-                            if (resistCheck > -1)
+                            if (!corruptionResistanceApplied && resistCheck > -1)
                             {
                                 totalStats[7] += 10;
+                                corruptionResistanceApplied = true;
                             }
                             var shortName = function (str1)
                             {


### PR DESCRIPTION
Only apply corruption resistance once even if multiple essences with corruption resistance are active.